### PR TITLE
Fix loading screen, set dark mode default, unify color scheme, remove gradients from sections, and hide scrollbar

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -10,7 +10,7 @@ import { ExperienceSection } from "./components/experience/ExperienceSection";
 import { Footer } from "./components/footer/Footer";
 import { Preview } from "./components/Preview";
 import { ScrollToTop } from "./components/ScrollToTop";
-import { ThemeProvider, useTheme } from "./components/ThemeProvider";
+import { useTheme } from "./components/ThemeProvider";
 import { AnimatedCursorComponent } from "./components/AnimatedCursorComponent";
 import { ExpandableChatDemo } from "./components/ui/chat-demo";
 
@@ -18,7 +18,7 @@ function AppContent() {
   useTheme();
 
   return (
-    <div className="flex flex-col min-h-screen bg-white dark:bg-gray-900">
+    <div className="flex flex-col min-h-screen bg-background">
       <AnimatedCursorComponent />
       <Navigation />
       <main className="flex-grow">
@@ -38,11 +38,7 @@ function AppContent() {
 }
 
 function App() {
-  return (
-    <ThemeProvider>
-      <AppContent />
-    </ThemeProvider>
-  );
+  return <AppContent />;
 }
 
 export default App; 

--- a/src/app/components/About.tsx
+++ b/src/app/components/About.tsx
@@ -2,7 +2,7 @@ import { motion } from "framer-motion";
 import { TechGrid } from "./TechGrid";
 export function About() {
   return (
-    <section id="about" className="py-20 bg-gray-50 dark:bg-gray-900">
+    <section id="about" className="py-20 bg-background">
       <div className="max-w-6xl mx-auto px-4">
         <motion.h2
           initial={{ opacity: 0, y: 20 }}
@@ -20,15 +20,15 @@ export function About() {
             viewport={{ once: true }}
             className="prose prose-lg max-w-none dark:prose-invert"
           >
-            <p className="text-lg text-gray-700 dark:text-gray-300">
+            <p className="text-lg text-muted-foreground">
               As a seasoned Senior Software Engineer with over 4 years of experience, I excel in architecting and developing enterprise-grade applications. My expertise spans the full software development lifecycle, from system design to deployment, with a particular focus on building scalable, high-performance solutions using cutting-edge technologies.
             </p>
-            <p className="text-lg text-gray-700 dark:text-gray-300">
+            <p className="text-lg text-muted-foreground">
               Throughout my career, I've led cross-functional teams in delivering complex projects, established engineering best practices, and mentored junior developers. I'm passionate about creating robust, maintainable codebases and driving technical innovation while ensuring optimal user experiences.
             </p>
           </motion.div>
           <div>
-            <h3 className="text-2xl font-semibold mb-8 text-center text-gray-800 dark:text-gray-200">
+            <h3 className="text-2xl font-semibold mb-8 text-center text-foreground">
               Technical Skills & Tools
             </h3>
             <TechGrid />

--- a/src/app/components/Hero.tsx
+++ b/src/app/components/Hero.tsx
@@ -71,7 +71,7 @@ export function Hero() {
   };
 
   return (
-    <section className="min-h-screen relative overflow-hidden bg-gradient-to-br from-gray-50 via-gray-50 to-blue-50 dark:from-gray-900 dark:via-gray-900 dark:to-blue-900/20">
+    <section className="min-h-screen relative overflow-hidden bg-gradient-to-br from-background via-background to-blue-50 dark:to-blue-900/20">
       {/* Background decorative elements */}
       <div className="absolute inset-0 overflow-hidden">
         <div className="absolute -top-40 -right-40 w-80 h-80 bg-blue-500/10 rounded-full blur-3xl" />
@@ -90,7 +90,7 @@ export function Hero() {
             initial={{ x: -50, opacity: 0 }}
             animate={{ x: 0, opacity: 1 }}
             transition={{ duration: 0.8, delay: 0.2 }}
-            className="w-full md:w-1/2 text-gray-900 dark:text-white space-y-6"
+            className="w-full md:w-1/2 text-foreground space-y-6"
           >
             <div className="space-y-4">
               <JobStatusBadge />
@@ -103,7 +103,7 @@ export function Hero() {
               </h1>
             </div>
 
-            <p className="text-lg text-gray-700 dark:text-gray-300 my-6 leading-relaxed">
+            <p className="text-lg text-muted-foreground my-6 leading-relaxed">
               A passionate Full Stack Software Engineer with 4+ years of
               experience in building scalable applications and creating
               exceptional user experiences.
@@ -118,7 +118,7 @@ export function Hero() {
 
                  
                   {/* Promptly */}
-                  <div className="flex items-center flex-wrap gap-x-2 gap-y-1 text-lg text-gray-700 dark:text-gray-300">
+                  <div className="flex items-center flex-wrap gap-x-2 gap-y-1 text-lg text-muted-foreground">
                     <span>Building</span>
                     <LinkPreview
                       url="https://beta.promptly.diy"
@@ -130,7 +130,7 @@ export function Hero() {
                     >
                       Promptly
                     </LinkPreview>
-                    <span className="text-sm text-gray-600 dark:text-gray-400">with 10+ AI Models</span>
+                    <span className="text-sm text-muted-foreground/70">with 10+ AI Models</span>
                     <span className="flex items-center gap-2">
                     <img
                         src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8e/Nextjs-logo.svg/1200px-Nextjs-logo.svg.png"
@@ -149,7 +149,7 @@ export function Hero() {
               </div>
 
                {/* Goodmoney */}
-               <div className="flex items-center flex-wrap gap-x-2 gap-y-1 text-lg text-gray-700 dark:text-gray-300">
+               <div className="flex items-center flex-wrap gap-x-2 gap-y-1 text-lg text-muted-foreground">
                     <span>Building</span>
                     <LinkPreview
                       url="https://goodmoney.xyz"
@@ -178,13 +178,13 @@ export function Hero() {
 
 
               <div className="flex items-center space-x-2">
-                <span className="text-xl font-bold text-gray-700 dark:text-gray-300">
+                <span className="text-xl font-bold text-foreground">
                   Used by
                 </span>
                 <div>
                   <AvatarCircles numPeople={10} avatarUrls={avatars} />
                 </div>
-                <span className="text-xl font-bold text-gray-700 dark:text-gray-300">
+                <span className="text-xl font-bold text-foreground">
                   Developers
                 </span>
               </div>

--- a/src/app/components/Navigation.tsx
+++ b/src/app/components/Navigation.tsx
@@ -45,7 +45,7 @@ export function Navigation() {
     <nav
       className={`fixed w-full z-50 transition-all duration-300 ${
         isScrolled
-          ? "bg-white/95 dark:bg-gray-900/95 backdrop-blur-sm shadow-lg"
+          ? "bg-background/95 backdrop-blur-sm shadow-lg"
           : "bg-transparent"
       }`}
     >
@@ -64,7 +64,7 @@ export function Navigation() {
               <motion.button
                 key={item}
                 onClick={() => scrollToSection(item.toLowerCase())}
-                className="text-gray-700 dark:text-gray-300 hover:text-blue-500 dark:hover:text-blue-400 transition-colors duration-200"
+                className="text-foreground hover:text-blue-500 dark:hover:text-blue-400 transition-colors duration-200"
                 whileHover={{ y: -2 }}
                 whileTap={{ y: 0 }}
               >
@@ -79,7 +79,7 @@ export function Navigation() {
             <motion.button
               whileHover={{ scale: 1.1 }}
               whileTap={{ scale: 0.9 }}
-              className="text-gray-700 dark:text-white"
+              className="text-foreground"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
             >
               {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
@@ -93,14 +93,14 @@ export function Navigation() {
               initial={{ opacity: 0, height: 0 }}
               animate={{ opacity: 1, height: "auto" }}
               exit={{ opacity: 0, height: 0 }}
-              className="md:hidden bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800"
+              className="md:hidden bg-background border-t border-border"
             >
               <div className="px-2 pt-2 pb-3 space-y-1">
                 {navItems.map((item) => (
                   <motion.button
                     key={item}
                     onClick={() => scrollToSection(item.toLowerCase())}
-                    className="block w-full text-left px-3 py-2 text-gray-700 dark:text-gray-300 hover:text-blue-500 dark:hover:text-blue-400 transition-colors duration-200"
+                    className="block w-full text-left px-3 py-2 text-foreground hover:text-blue-500 dark:hover:text-blue-400 transition-colors duration-200"
                     whileHover={{ x: 5 }}
                   >
                     {item}

--- a/src/app/components/Preview.tsx
+++ b/src/app/components/Preview.tsx
@@ -5,7 +5,7 @@ function Preview() {
   return (
     <section
       id="playground"
-      className="w-full h-[500px] relative bg-white dark:bg-gray-900 z-0 overflow-hidden"
+      className="w-full h-[500px] relative bg-background z-0 overflow-hidden"
     >
       <div className="w-[98%] h-[98%] mx-auto relative">
         <Gravity

--- a/src/app/components/Projects.tsx
+++ b/src/app/components/Projects.tsx
@@ -3,7 +3,7 @@ import { ProjectsGrid } from "./projects/ProjectsGrid";
 
 export function Projects() {
   return (
-    <section id="projects" className="py-20 bg-gray-50 dark:bg-gray-900">
+    <section id="projects" className="py-20 bg-background">
       <div className="max-w-6xl mx-auto px-4">
         <motion.h2
           initial={{ opacity: 0, y: 20 }}

--- a/src/app/components/Publications.tsx
+++ b/src/app/components/Publications.tsx
@@ -4,7 +4,7 @@ import { publications } from "../data/publications";
 
 export function Publications() {
   return (
-    <section id="publications" className="py-20 bg-gray-50 dark:bg-gray-900">
+    <section id="publications" className="py-20 bg-background">
       <div className="max-w-6xl mx-auto px-4">
         <motion.h2
           initial={{ opacity: 0, y: 20 }}
@@ -22,26 +22,26 @@ export function Publications() {
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
-              className="bg-white dark:bg-gray-800 rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300"
+              className="bg-card rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300"
             >
               <div className="p-6">
-                <h3 className="text-xl font-semibold mb-2 text-gray-900 dark:text-white">
+                <h3 className="text-xl font-semibold mb-2 text-card-foreground">
                   {pub.title}
                 </h3>
-                <p className="text-gray-600 dark:text-gray-300 mb-4">
+                <p className="text-muted-foreground mb-4">
                   {pub.venue}
                 </p>
                 <div className="space-y-2 mb-4">
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                  <p className="text-sm text-muted-foreground/70">
                     <span className="font-medium">Authors:</span> {pub.authors}
                   </p>
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                  <p className="text-sm text-muted-foreground/70">
                     <span className="font-medium">Publisher:</span> {pub.publisher}
                   </p>
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                  <p className="text-sm text-muted-foreground/70">
                     <span className="font-medium">Year:</span> {pub.year}
                   </p>
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                  <p className="text-sm text-muted-foreground/70">
                     <span className="font-medium">DOI:</span> {pub.doi}
                   </p>
                 </div>

--- a/src/app/components/Recommendations.tsx
+++ b/src/app/components/Recommendations.tsx
@@ -19,7 +19,7 @@ export function Recommendations() {
 
   return (
     <>
-      <section id="recommendations" className="py-20 bg-gray-50 dark:bg-gray-900">
+      <section id="recommendations" className="py-20 bg-background">
         <div className="max-w-6xl mx-auto px-4">
           <motion.h2
             initial={{ opacity: 0, y: 20 }}
@@ -38,7 +38,7 @@ export function Recommendations() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ delay: index * 0.1 }}
-                className="bg-white dark:bg-gray-800 rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-all duration-300 cursor-pointer group"
+                className="bg-card rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-all duration-300 cursor-pointer group"
                 onClick={() => handleCardClick(recommendation)}
               >
                 <div className="p-6">
@@ -55,7 +55,7 @@ export function Recommendations() {
                     </div>
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">
-                        <h3 className="font-semibold text-gray-900 dark:text-white truncate">
+                        <h3 className="font-semibold text-card-foreground truncate">
                           {recommendation.authorName}
                         </h3>
                         {recommendation.isVerified && (
@@ -66,10 +66,10 @@ export function Recommendations() {
                           </div>
                         )}
                       </div>
-                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                      <p className="text-sm text-muted-foreground">
                         @{recommendation.authorHandle}
                       </p>
-                      <p className="text-xs text-gray-500 dark:text-gray-500 mt-1">
+                      <p className="text-xs text-muted-foreground/70 mt-1">
                         {recommendation.timestamp}
                       </p>
                     </div>
@@ -79,25 +79,25 @@ export function Recommendations() {
                   {/* Content Preview */}
                   <div className="space-y-2">
                     {recommendation.content.map((line, idx) => (
-                      <p key={idx} className="text-gray-700 dark:text-gray-300 text-sm leading-relaxed">
+                      <p key={idx} className="text-muted-foreground text-sm leading-relaxed">
                         {line}
                       </p>
                     ))}
                   </div>
 
                   {/* Read More Indicator */}
-                  <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+                  <div className="mt-4 pt-4 border-t border-border">
                     <div className="flex items-center justify-between">
-                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                      <span className="text-xs text-muted-foreground/70">
                         Click to read full recommendation
                       </span>
-                      <ExternalLink className="h-4 w-4 text-gray-400 group-hover:text-blue-500 dark:group-hover:text-blue-400 transition-colors" />
+                      <ExternalLink className="h-4 w-4 text-muted-foreground group-hover:text-blue-500 dark:group-hover:text-blue-400 transition-colors" />
                     </div>
                   </div>
 
                   {/* Reply Preview */}
                   {recommendation.reply && (
-                    <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+                    <div className="mt-4 pt-4 border-t border-border">
                       <div className="flex gap-3">
                         <div className="h-8 w-8 rounded-full overflow-hidden flex-shrink-0">
                           <img
@@ -107,12 +107,12 @@ export function Recommendations() {
                           />
                         </div>
                         <div className="flex-1">
-                          <div className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
+                          <div className="flex items-center gap-2 text-xs text-muted-foreground">
                             <span className="font-medium">{recommendation.reply.authorName}</span>
                             <span>•</span>
                             <span>{recommendation.reply.timestamp}</span>
                           </div>
-                          <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                          <p className="text-sm text-muted-foreground mt-1">
                             {recommendation.reply.content}
                           </p>
                         </div>
@@ -127,9 +127,9 @@ export function Recommendations() {
       </section>
 
       <Dialog open={!!selectedRecommendation} onOpenChange={() => handleCloseDialog()}>
-        <DialogContent className="bg-white dark:bg-gray-800">
+        <DialogContent className="bg-card">
           <DialogHeader>
-            <DialogTitle className="text-gray-900 dark:text-white">LinkedIn Recommendation</DialogTitle>
+            <DialogTitle className="text-card-foreground">LinkedIn Recommendation</DialogTitle>
             <DialogClose onClose={handleCloseDialog} />
           </DialogHeader>
           
@@ -147,7 +147,7 @@ export function Recommendations() {
                 </div>
                 <div className="flex-1">
                   <div className="flex items-center gap-3">
-                    <h3 className="text-xl font-semibold text-gray-900 dark:text-white">
+                    <h3 className="text-xl font-semibold text-card-foreground">
                       {selectedRecommendation.authorName}
                     </h3>
                     {selectedRecommendation.isVerified && (
@@ -159,26 +159,26 @@ export function Recommendations() {
                     )}
                     <LinkedinIcon className="h-6 w-6 text-blue-600 dark:text-blue-400" />
                   </div>
-                  <p className="text-gray-600 dark:text-gray-400 mt-1">
+                  <p className="text-muted-foreground mt-1">
                     @{selectedRecommendation.authorHandle}
                   </p>
-                  <p className="text-sm text-gray-500 dark:text-gray-500 mt-1">
+                  <p className="text-sm text-muted-foreground/70 mt-1">
                     {selectedRecommendation.timestamp}
                   </p>
                 </div>
               </div>
               
               <div className="mb-6">
-                <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
-                  <p className="text-gray-800 dark:text-gray-200 leading-relaxed whitespace-pre-line">
+                <div className="bg-muted rounded-lg p-4">
+                  <p className="text-card-foreground leading-relaxed whitespace-pre-line">
                     {selectedRecommendation.fullContent}
                   </p>
                 </div>
               </div>
               
               {selectedRecommendation.reply && (
-                <div className="mb-6 pt-4 border-t border-gray-200 dark:border-gray-700">
-                  <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Your Response</h4>
+                <div className="mb-6 pt-4 border-t border-border">
+                  <h4 className="text-sm font-medium text-muted-foreground mb-3">Your Response</h4>
                   <div className="flex gap-3">
                     <div className="flex-shrink-0">
                       <div className="h-10 w-10 rounded-full overflow-hidden">
@@ -191,35 +191,20 @@ export function Recommendations() {
                     </div>
                     <div className="flex-1">
                       <div className="flex items-center gap-2 mb-1">
-                        <span className="font-medium text-gray-900 dark:text-white text-sm">
+                        <span className="font-medium text-card-foreground text-sm">
                           {selectedRecommendation.reply.authorName}
                         </span>
-                        <span className="text-gray-500 dark:text-gray-400 text-sm">
+                        <span className="text-muted-foreground text-sm">
                           • {selectedRecommendation.reply.timestamp}
                         </span>
                       </div>
-                      <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3">
-                        <p className="text-gray-700 dark:text-gray-300 text-sm">
-                          {selectedRecommendation.reply.content}
-                        </p>
-                      </div>
+                      <p className="text-sm text-muted-foreground">
+                        {selectedRecommendation.reply.content}
+                      </p>
                     </div>
                   </div>
                 </div>
               )}
-              
-              <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
-                <a
-                  href={selectedRecommendation.link}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 transition-colors font-medium"
-                >
-                  <LinkedinIcon className="h-5 w-5" />
-                  View on LinkedIn
-                  <ExternalLink className="h-4 w-4" />
-                </a>
-              </div>
             </div>
           )}
         </DialogContent>

--- a/src/app/components/TechGrid.tsx
+++ b/src/app/components/TechGrid.tsx
@@ -60,20 +60,20 @@ export function TechGrid() {
                 <motion.div
                   key={techIndex}
                   whileHover={{ scale: 1.05 }}
-                  className="flex flex-col items-center p-4 bg-gray-100 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
+                  className="flex flex-col items-center p-4 bg-card rounded-lg border border-border"
                 >
                   {iconPath && (
                     <svg
                       role="img"
                       viewBox="0 0 24 24"
-                      className="w-8 h-8 mb-2 text-gray-700 dark:text-gray-300"
+                      className="w-8 h-8 mb-2 text-muted-foreground"
                       fill="currentColor"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path d={iconPath} />
                     </svg>
                   )}
-                  <span className="text-sm text-gray-600 dark:text-gray-400">
+                  <span className="text-sm text-muted-foreground">
                     {tech.name}
                   </span>
                 </motion.div>

--- a/src/app/components/ThemeProvider.tsx
+++ b/src/app/components/ThemeProvider.tsx
@@ -11,20 +11,20 @@ const ThemeContext = createContext<{
   theme: Theme;
   toggleTheme: () => void;
 }>({
-  theme: "light",
+  theme: "dark",
   toggleTheme: () => {},
 });
 
 export function ThemeProvider({ children }: ThemeProviderProps) {
   const [mounted, setMounted] = useState(false);
-  const [theme, setTheme] = useState<Theme>("light");
+  const [theme, setTheme] = useState<Theme>("dark");
 
   useEffect(() => {
     const stored = localStorage.getItem("theme");
     const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
     const initialTheme = stored === "dark" || stored === "light" 
       ? stored 
-      : prefersDark ? "dark" : "light";
+      : prefersDark ? "dark" : "dark";
     
     setTheme(initialTheme);
     setMounted(true);

--- a/src/app/components/experience/ExperienceCard.tsx
+++ b/src/app/components/experience/ExperienceCard.tsx
@@ -27,7 +27,7 @@ export function ExperienceCard({
       className={`p-6 rounded-lg cursor-pointer transition-all duration-300 ${
         isSelected
           ? "bg-blue-500/10 dark:bg-blue-500/5"
-          : "hover:bg-gray-100/50 dark:hover:bg-gray-800/50"
+          : "hover:bg-muted/50"
       }`}
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
@@ -47,15 +47,15 @@ export function ExperienceCard({
           company
         )}
       </h3>
-      <h4 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">
+      <h4 className="text-lg font-semibold text-foreground mb-1">
         {title}
       </h4>
-      <p className="text-sm text-gray-500 dark:text-gray-400 font-mono mb-4">
+      <p className="text-sm text-muted-foreground font-mono mb-4">
         {duration}
       </p>
       <ul className="list-disc list-inside space-y-2 mb-4">
         {description.map((item, index) => (
-          <li key={index} className="text-gray-600 dark:text-gray-300">
+          <li key={index} className="text-muted-foreground">
             {item}
           </li>
         ))}
@@ -64,7 +64,7 @@ export function ExperienceCard({
         {technologies.map((tech, index) => (
           <span
             key={index}
-            className="text-xs px-2 py-1 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400"
+            className="text-xs px-2 py-1 rounded-full bg-muted text-muted-foreground"
           >
             {tech}
           </span>

--- a/src/app/components/experience/ExperienceSection.tsx
+++ b/src/app/components/experience/ExperienceSection.tsx
@@ -14,7 +14,7 @@ export function ExperienceSection() {
     experiences.find((exp) => exp.category === activeTab)?.items || [];
 
   return (
-    <section id="experience" className="py-20 bg-white dark:bg-gray-900">
+    <section id="experience" className="py-20 bg-background">
       <div className="max-w-5xl mx-auto px-4">
         <motion.h2
           initial={{ opacity: 0, y: 20 }}

--- a/src/app/components/footer/Footer.tsx
+++ b/src/app/components/footer/Footer.tsx
@@ -43,12 +43,18 @@ const socialLinks = [
 
 export function Footer() {
   return (
-    <footer className="bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800 mt-auto">
-      <div className="max-w-6xl mx-auto px-4 py-6">
+    <footer className="relative overflow-hidden bg-gradient-to-br from-background via-background to-blue-50 dark:to-blue-900/20 border-t border-border mt-auto">
+      {/* Background decorative elements */}
+      <div className="absolute inset-0 overflow-hidden">
+        <div className="absolute -top-40 -right-40 w-80 h-80 bg-blue-500/10 rounded-full blur-3xl" />
+        <div className="absolute -bottom-40 -left-40 w-80 h-80 bg-purple-500/10 rounded-full blur-3xl" />
+      </div>
+      
+      <div className="relative max-w-6xl mx-auto px-4 py-6">
         <div className="flex flex-col md:flex-row justify-between items-center gap-4">
-          <p className="text-gray-600 dark:text-gray-400 text-center md:text-left">
+          <p className="text-muted-foreground text-center md:text-left">
             Designed by{" "}
-            <span className="font-medium text-gray-900 dark:text-white">
+            <span className="font-medium text-foreground">
               Sri Ganesh Shiramshetty
             </span>
           </p>

--- a/src/app/components/projects/ProjectCard.tsx
+++ b/src/app/components/projects/ProjectCard.tsx
@@ -23,7 +23,7 @@ export function ProjectCard({
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
-      className="bg-white dark:bg-gray-900 rounded-lg overflow-hidden border border-gray-200 dark:border-gray-800 group"
+      className="bg-card rounded-lg overflow-hidden border border-border group"
     >
       {/* Image with 16:9 aspect ratio */}
       <div className="relative overflow-hidden aspect-w-16 aspect-h-9">
@@ -37,17 +37,17 @@ export function ProjectCard({
         </motion.div>
       </div>
       <div className="p-6">
-        <h3 className="text-2xl font-bold mb-2 text-gray-900 dark:text-blue-400 group-hover:text-blue-600 dark:group-hover:text-blue-300 transition-colors">
+        <h3 className="text-2xl font-bold mb-2 text-card-foreground group-hover:text-blue-600 dark:group-hover:text-blue-300 transition-colors">
           {title}
         </h3>
-        <p className="text-gray-600 dark:text-gray-300 mb-4 line-clamp-6">
+        <p className="text-muted-foreground mb-4 line-clamp-6">
           {description}
         </p>
         <div className="flex flex-wrap gap-2 mb-4">
           {tech.map((item, i) => (
             <span
               key={i}
-              className="px-3 py-1 text-sm bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-blue-400 rounded-full border border-gray-200 dark:border-gray-700"
+              className="px-3 py-1 text-sm bg-muted text-muted-foreground rounded-full border border-border"
             >
               {item}
             </span>
@@ -60,7 +60,7 @@ export function ProjectCard({
             href={github}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-2 text-gray-600 dark:text-gray-300 hover:text-blue-500 dark:hover:text-blue-400 transition-colors"
+            className="flex items-center gap-2 text-muted-foreground hover:text-blue-500 dark:hover:text-blue-400 transition-colors"
           >
             <Github size={20} />
             <span>Code</span>
@@ -71,7 +71,7 @@ export function ProjectCard({
             href={demo}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-2 text-gray-600 dark:text-gray-300 hover:text-blue-500 dark:hover:text-blue-400 transition-colors"
+            className="flex items-center gap-2 text-muted-foreground hover:text-blue-500 dark:hover:text-blue-400 transition-colors"
           >
             <ExternalLink size={20} />
             <span>Demo</span>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from 'next/font/google'
 import '../index.css'
 import { Loading } from '@/components/loading'
 import { Analytics } from '@vercel/analytics/next'
+import { ThemeProvider } from './components/ThemeProvider'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -70,9 +71,11 @@ export default function RootLayout({
         <link rel="canonical" href="https://srishiram.xyz" />
       </head>
       <body className={inter.className}>
-        <Loading />
-        {children}
-        <Analytics />
+        <ThemeProvider>
+          <Loading />
+          {children}
+          <Analytics />
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/src/components/loading.tsx
+++ b/src/components/loading.tsx
@@ -5,14 +5,31 @@ import { AppleHelloEnglishEffect } from "@/components/ui/apple-hello-effect";
 
 export function Loading() {
   const [isVisible, setIsVisible] = useState(true);
+  const [animationCompleted, setAnimationCompleted] = useState(false);
 
   useEffect(() => {
-    const timer = setTimeout(() => {
+    // Fallback timer to ensure loading screen doesn't get stuck
+    const fallbackTimer = setTimeout(() => {
       setIsVisible(false);
-    }, 4000); // Hide after 4 seconds
+    }, 6000); // 6 seconds fallback
 
-    return () => clearTimeout(timer);
+    return () => clearTimeout(fallbackTimer);
   }, []);
+
+  const handleAnimationComplete = () => {
+    setAnimationCompleted(true);
+    // Hide loading screen after animation completes with a small delay
+    setTimeout(() => {
+      setIsVisible(false);
+    }, 500);
+  };
+
+  const handleAnimationError = () => {
+    // If animation fails, hide loading screen after 2 seconds
+    setTimeout(() => {
+      setIsVisible(false);
+    }, 2000);
+  };
 
   if (!isVisible) return null;
 
@@ -22,9 +39,8 @@ export function Loading() {
         <AppleHelloEnglishEffect 
           speed={1.1} 
           className="text-primary"
-          onAnimationComplete={() => {
-            console.log("Animation completed");
-          }}
+          onAnimationComplete={handleAnimationComplete}
+          onError={handleAnimationError}
         />
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -24,7 +24,7 @@
   }
 
   body {
-    @apply bg-gray-900 text-white;
+    @apply bg-background text-foreground;
   }
   :root {
     --background: 0 0% 100%;
@@ -124,20 +124,19 @@
   animation: gradient 15s ease infinite;
 }
 
+/* Hide scrollbar for webkit browsers */
 ::-webkit-scrollbar {
-  width: 10px;
+  display: none;
 }
 
-::-webkit-scrollbar-track {
-  @apply bg-gray-900;
+/* Hide scrollbar for Firefox */
+* {
+  scrollbar-width: none;
 }
 
-::-webkit-scrollbar-thumb {
-  @apply bg-blue-500/50 rounded-full;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  @apply bg-blue-500/70;
+/* Hide scrollbar for IE/Edge */
+* {
+  -ms-overflow-style: none;
 }
 
 /* Hide scrollbar utility */


### PR DESCRIPTION
This PR fixes the loading screen getting stuck, sets dark mode as default, unifies the color scheme across all sections, removes gradients from all sections except Hero and Footer, and hides the scrollbar for a cleaner look.